### PR TITLE
fix: Removing the no-plusplus linting rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,6 +31,7 @@ module.exports = {
     'react/jsx-props-no-spreading': 'off',
     'react/jsx-one-expression-per-line': 'off',
     'react/destructuring-assignment': 'off',
+    'no-plusplus': 'off',
     strict: 'off'
   }
 }

--- a/test.js
+++ b/test.js
@@ -11,3 +11,7 @@ class MethodDoesNotUseThis {
     const bar = 'hah';
   }
 }
+
+// disable no-plusplus
+let i = 0;
+i++;


### PR DESCRIPTION
We seem to agree that we want to be able to use the `++` operator.

This PR turns off the eslint rule restricting its use.