### PR TITLE
fix: allow labels to satisfy htmlFor a11y requirement instead of both nesting and htmlFor

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,6 +28,13 @@ module.exports = {
       }
     ],
     'arrow-parens': 'off',
+    'jsx-a11y/label-has-associated-control': ['error', {
+      labelComponents: [],
+      labelAttributes: [],
+      controlComponents: [],
+      assert: 'either',
+      depth: 25
+    }],
     'react/jsx-props-no-spreading': 'off',
     'react/jsx-one-expression-per-line': 'off',
     'react/destructuring-assignment': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,7 +32,7 @@ module.exports = {
       labelComponents: [],
       labelAttributes: [],
       controlComponents: [],
-      assert: 'either',
+      assert: 'htmlFor',
       depth: 25
     }],
     'react/jsx-props-no-spreading': 'off',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1342,9 +1342,9 @@
       "dev": true
     },
     "react-is": {
-      "version": "16.12.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
-      "integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==",
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
     },
     "read-pkg": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "./node_modules/.bin/eslint .",
-    "test": "./node_modules/.bin/eslint test.js"
+    "test": "./node_modules/.bin/eslint test.jsx"
   },
   "publishConfig": {
     "access": "public"

--- a/test.jsx
+++ b/test.jsx
@@ -1,3 +1,4 @@
+import React from 'react'; // eslint-disable-line import/no-unresolved
 /* eslint-disable no-unused-vars */
 
 // Tests for custom rules in .eslintrc.js
@@ -9,6 +10,15 @@ const foo = bar => bar.id;
 class MethodDoesNotUseThis {
   foo() {
     const bar = 'hah';
+  }
+
+  render() {
+    return (
+      <>
+        <label htmlFor="the-input">The input</label>
+        <input id="the-input" type="text" value="hi" />
+      </>
+    );
   }
 }
 


### PR DESCRIPTION
Labels can now satisfy the a11y requirement with just `htmlFor`

```
<label htmlFor="name">Name</label>
<input id="name" type="text" />
```

Nesting alone will now fail

```
<label>
  Name
  <input id="name" type="text" />
</label>
```

Background: https://github.com/airbnb/javascript/issues/1885
