### PR TITLE
feat: Use simple import order plugin to sort imports and exports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,6 +11,7 @@ module.exports = {
     // as peer dependencies.
     'airbnb',
   ],
+  plugins: ['simple-import-sort'],
   // If you add rule overrides here, add code to test.js that proves you formatted it right.
   rules: {
     'class-methods-use-this': 'off',
@@ -24,8 +25,8 @@ module.exports = {
         ignoreComments: false,
         ignoreRegExpLiterals: true,
         ignoreStrings: true,
-        ignoreTemplateLiterals: true
-      }
+        ignoreTemplateLiterals: true,
+      },
     ],
     'arrow-parens': 'off',
     'jsx-a11y/label-has-associated-control': ['error', {
@@ -33,12 +34,29 @@ module.exports = {
       labelAttributes: [],
       controlComponents: [],
       assert: 'htmlFor',
-      depth: 25
+      depth: 25,
     }],
+    'simple-import-sort/imports': [
+      'error', {
+        groups: [
+          // These packages provide polyfills so should always be first
+          ['core-js', 'regenerator-runtime'],
+          // React packages should come at the top
+          ['^react$', '^react-dom$', '^prop-types'],
+          // Non-react third-party packages come next
+          ['^@?\\w'],
+          // Packages from the @edx namespace come after that
+          ['^@edx?\\w'],
+          // Finally we have internal, relative imports
+          ['^\\.\\.(?!/?$)', '^\\.\\./?$', '^\\./(?=.*/)(?!/?$)', '^\\.(?!/?$)', '^\\./?$'],
+        ],
+      },
+    ],
+    'simple-import-sort/exports': 'error',
     'react/jsx-props-no-spreading': 'off',
     'react/jsx-one-expression-per-line': 'off',
     'react/destructuring-assignment': 'off',
     'no-plusplus': 'off',
-    strict: 'off'
-  }
-}
+    strict: 'off',
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1297,6 +1297,11 @@
       "integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==",
       "dev": true
     },
+    "eslint-plugin-simple-import-sort": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-7.0.0.tgz",
+      "integrity": "sha512-U3vEDB5zhYPNfxT5TYR7u01dboFZp+HNpnGhkDB2g/2E4wZ/g1Q9Ton8UwCLfRV9yAKyYqDh62oHOamvkFxsvw=="
+    },
     "eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "eslint-plugin-import": "2.23.4",
     "eslint-plugin-jsx-a11y": "6.4.1",
     "eslint-plugin-react": "7.24.0",
-    "eslint-plugin-react-hooks": "4.2.0"
+    "eslint-plugin-react-hooks": "4.2.0",
+    "eslint-plugin-simple-import-sort": "^7.0.0"
   },
   "peerDependencies": {
     "eslint": "^6.8.0 || ^7.0.0",
@@ -39,6 +40,7 @@
     "eslint-plugin-import": "^2.20.0",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-react": "^7.18.0",
-    "eslint-plugin-react-hooks": "^1.7.0 || ^4.0.0"
+    "eslint-plugin-react-hooks": "^1.7.0 || ^4.0.0",
+    "eslint-plugin-simple-import-sort": "^5.0.0 || ^7.0.0"
   }
 }


### PR DESCRIPTION
In a recent PR [it was recommended](https://github.com/edx/frontend-app-discussions/pull/8#discussion_r661348720) that I sort imports in the order of react import, external imports, and relative imports. 

This PR adds eslint config to simplify adhering to this. It groups and sorts imports into: 
- React impots
- Third party imports
- @edx/* imports 
- internal/relative imports

This somewhat matches the python world. 