### PR TITLE
feat: turn off react-in-jsx-scope

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,6 +36,7 @@ module.exports = {
       depth: 25,
     }],
     'react/jsx-props-no-spreading': 'off',
+    'react/react-in-jsx-scope': 'off',
     'react/jsx-one-expression-per-line': 'off',
     'react/destructuring-assignment': 'off',
     'no-plusplus': 'off',

--- a/test.jsx
+++ b/test.jsx
@@ -1,4 +1,3 @@
-import React from 'react'; // eslint-disable-line import/no-unresolved
 /* eslint-disable no-unused-vars */
 
 // Tests for custom rules in .eslintrc.js


### PR DESCRIPTION
As a pre-requisite to updating to React 17 and using the new JSX transform, we want to turn off this eslint rule so all our code doesn't start complaining about React not being imported.

https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/react-in-jsx-scope.md
https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html

If we don't remove this, then when we start deleting "import React from 'react'" lines in our codebase, they'll become linting errors.