### PR TITLE
chore: allow usage of eslint-config-airbnb 19.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -988,9 +988,9 @@
       }
     },
     "eslint-plugin-react-hooks": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz",
-      "integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz",
+      "integrity": "sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==",
       "dev": true
     },
     "eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -31,11 +31,11 @@
     "eslint-plugin-import": "2.25.3",
     "eslint-plugin-jsx-a11y": "6.5.1",
     "eslint-plugin-react": "7.27.1",
-    "eslint-plugin-react-hooks": "4.2.0"
+    "eslint-plugin-react-hooks": "4.3.0"
   },
   "peerDependencies": {
     "eslint": "^6.8.0 || ^7.0.0 || ^8.0.0",
-    "eslint-config-airbnb": "^18.0.1",
+    "eslint-config-airbnb": "^18.0.1 || ^19.0.0",
     "eslint-plugin-import": "^2.20.0",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-react": "^7.18.0",


### PR DESCRIPTION
# Summary

* Updates peer dependencies to include eslint-config-airbnb 19.
* Updates eslint-plugin-react-hooks to a version that includes eslint 8 as a
peer dependency.

# Notes

* Using eslint-config-airbnb v19 with an existing codebase that uses this config may result in linting errors that previously did not exist.  
  * See errors in prospectus after the update: https://github.com/edx/eslint-config/pull/50#issuecomment-990227434
  * See the rules that would need to be changed for stability in prospectus after the update: https://github.com/edx/eslint-config/commit/98fd925aa25f97bb9d130bdd2796e60daab1e41e