### PR TITLE
feat: don't ever require defaultProps which are now deprecated

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -71,12 +71,9 @@ module.exports = {
     'react/destructuring-assignment': 'off',
     'no-plusplus': 'off',
     strict: 'off',
-    // We don't require 'defaultProps' for function components (they're
-    // deprecated: https://github.com/facebook/react/pull/16210).
+    // 'defaultProps' are deprecated (https://github.com/facebook/react/pull/16210)
+    // so don't ever require them.
     // It's better to use native JavaScript/TypeScript defaults and TS types.
-    'react/require-default-props': ['error', {
-      classes: 'defaultProps',
-      functions: 'ignore',
-    }],
+    'react/require-default-props': 'off',
   },
 };


### PR DESCRIPTION
See discussion at https://github.com/openedx/paragon/pull/3714#discussion_r2243901692 for an example of us hitting false positives with this rule enabled. Since `defaultProps` are deprecated, I think it makes sense to just completely disable this rule.

Side note: this repo has a lot of outdated dependencies... we'd probably be getting fixes like this automatically if we pulled those in. But it could also break a lot of existing lints, depending on what has changed upstream.