### PR TITLE
test: Remove support for Node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,6 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node: [20, 24]
     steps:
     - name: Checkout
       uses: actions/checkout@v4


### PR DESCRIPTION
### Description

As a second step in the Node 24 upgrade process, upgrade `.nvmrc` and regenerate `package-lock.json` from scratch using Node 24. Also make the Node 24 test a blocking one.

See [the tracking issue](https://github.com/openedx/eslint-config/issues/177) for further information.
